### PR TITLE
Improve appearance of highlight annotations

### DIFF
--- a/AnnotationRenderer.js
+++ b/AnnotationRenderer.js
@@ -141,6 +141,12 @@ class AnnotationRenderer {
 
 				el.prepend(bubble);
 			}
+			else if (annotation.type === "highlight") {
+				el.style.backgroundColor = "";
+				el.style.border = `2.5px solid ${this.getFinalAnnotationColor(annotationAppearance, false)}`;
+				if (annotation.actionType === "url")
+					el.style.cursor = "pointer";
+			}
 			else if (annotation.style !== "title") {
 				el.style.backgroundColor = this.getFinalAnnotationColor(annotationAppearance);
 				el.addEventListener("mouseenter", () => {


### PR DESCRIPTION
Quick fix to add support for `highlight` annotations, which were previously being displayed as `type="text"`. I'm not sure if there's any other attributes that need to be used. Let me know if this needs to go somewhere else or any other changes need to be made.

For [this](https://dev.invidio.us/watch?v=GOiIxqcbzyM) video.

Before:
![image](https://user-images.githubusercontent.com/14208607/54076744-4f903080-4274-11e9-8a50-c3bcab70456f.png)

After:
![image](https://user-images.githubusercontent.com/14208607/54076747-5ae35c00-4274-11e9-8d6f-1c25d155b978.png)

Reference:
![image](https://user-images.githubusercontent.com/14208607/54076750-659df100-4274-11e9-93ef-bdd279f2cb3a.png)

