### PR TITLE
Fix annotationAppearance

### DIFF
--- a/AnnotationRenderer.js
+++ b/AnnotationRenderer.js
@@ -85,10 +85,9 @@ class AnnotationRenderer {
 				annotationAppearance.bgColor = annotation.bgColor;
 			}
 
-			annotation.bgColor = annotationAppearance.bgColor;
-			annotation.bgOpacity = annotationAppearance.bgOpacity;
-			annotation.fgColor = annotationAppearance.fgColor;
-			annotation.textSize = annotationAppearance.textSize;
+			if (!isNaN(annotation.bgOpacity)) {
+				annotationAppearance.bgOpacity = annotation.bgOpacity;
+			}
 
 			if (annotation.text) {
 				const textNode = document.createElement("span");


### PR DESCRIPTION
Attributes appear to be copied in reverse, so the desired annotation is being overwritten with the default attributes. You can see this for example on [this video](https://dev.invidio.us/watch?v=EBGqUzObNmE) the opacity is too high.

Before:
![image](https://user-images.githubusercontent.com/14208607/54546653-222d3c00-4972-11e9-9c90-cf18940f915a.png)

After:
![image](https://user-images.githubusercontent.com/14208607/54546667-2c4f3a80-4972-11e9-9bd3-f38af180007a.png)

I'm not sure if this is the correct fix, let me know if anything needs to be changed.