### PR TITLE
Move styling into AnnotationRenderer

### DIFF
--- a/AnnotationParser.js
+++ b/AnnotationParser.js
@@ -1,4 +1,13 @@
 class AnnotationParser {
+	static get defaultAppearanceAttributes() {
+		return {
+			bgColor: 0xFFFFFF,
+			bgOpacity: 0.80,
+			fgColor: 0,
+			textSize: 3.15
+		};
+	}
+
 	static get attributeMap() {
 		return {
 			type: "tp",
@@ -215,6 +224,8 @@ class AnnotationParser {
 	}
 	getAppearanceFromBase(base) {
 		const appearanceElement = base.getElementsByTagName("appearance")[0];
+		const styles = this.constructor.defaultAppearanceAttributes;
+
 		if (appearanceElement) {
 			const bgOpacity = appearanceElement.getAttribute("bgAlpha");
 			const bgColor = appearanceElement.getAttribute("bgColor");
@@ -223,7 +234,6 @@ class AnnotationParser {
 			// not yet sure what to do with effects 
 			// const effects = appearanceElement.getAttribute("effects");
 
-			const styles = {};
 			// 0.00 to 1.00
 			if (bgOpacity) styles.bgOpacity = parseFloat(bgOpacity, 10);
 			// 0 to 256 ** 3
@@ -231,9 +241,9 @@ class AnnotationParser {
 			if (fgColor) styles.fgColor = parseInt(fgColor, 10);
 			// 0.00 to 100.00?
 			if (textSize) styles.textSize = parseFloat(textSize, 10);
-
-			return styles;
 		}
+
+		return styles;
 	}
 
 	/* helper functions */

--- a/AnnotationRenderer.js
+++ b/AnnotationRenderer.js
@@ -1,14 +1,4 @@
 class AnnotationRenderer {
-
-	static get defaultAppearanceAttributes() {
-		return {
-			bgColor: 0xFFFFFF,
-			bgOpacity: 0.80,
-			fgColor: 0,
-			textSize: 3.15
-		};
-	}
-
 	constructor(annotations, container, playerOptions, updateInterval = 1000) {
 		if (!annotations) throw new Error("Annotation objects must be provided");
 		if (!container) throw new Error("An element to contain the annotations must be provided");
@@ -69,31 +59,6 @@ class AnnotationRenderer {
 			});
 			el.append(closeButton);
 
-			// appearance
-			let annotationAppearance = this.constructor.defaultAppearanceAttributes;
-			if (!isNaN(annotation.textSize)) {
-				// text size calculations
-				// https://github.com/Seirade/YouTube-Annotation-Player/blob/ca763944c4bc947d44ba975c1f07fc0438b51cd3/annotations.js#L88
-				annotationAppearance.textSize = annotation.textSize;
-			}
-
-			if (!isNaN(annotation.fgColor)) {
-				annotationAppearance.fgColor = annotation.fgColor;
-			}
-
-			if (!isNaN(annotation.bgColor)) {
-				annotationAppearance.bgColor = annotation.bgColor;
-			}
-
-			if (!isNaN(annotation.bgOpacity)) {
-				annotationAppearance.bgOpacity = annotation.bgOpacity;
-			}
-
-			annotation.bgColor = annotationAppearance.bgColor;
-			annotation.bgOpacity = annotationAppearance.bgOpacity;
-			annotation.fgColor = annotationAppearance.fgColor;
-			annotation.textSize = annotationAppearance.textSize;
-
 			if (annotation.text) {
 				const textNode = document.createElement("span");
 				textNode.textContent = annotation.text;
@@ -112,7 +77,7 @@ class AnnotationRenderer {
 				const speechPointX = this.percentToPixels(containerDimensions.width, annotation.sx);
 				const speechPointY = this.percentToPixels(containerDimensions.height, annotation.sy);
 
-				const bubbleColor = this.getFinalAnnotationColor(annotationAppearance, false);
+				const bubbleColor = this.getFinalAnnotationColor(annotation, false);
 				const bubble = this.createSvgSpeechBubble(speechX, speechY, speechWidth, speechHeight, speechPointX, speechPointY, bubbleColor, annotation.__element);
 				bubble.style.display = "none";
 				bubble.style.overflow = "visible";
@@ -125,14 +90,14 @@ class AnnotationRenderer {
 					closeButton.style.display = "block";
 					// path.style.cursor = "pointer";
 					closeButton.style.cursor = "pointer";
-					path.setAttribute("fill", this.getFinalAnnotationColor(annotationAppearance, true));
+					path.setAttribute("fill", this.getFinalAnnotationColor(annotation, true));
 				});
 				path.addEventListener("mouseout", e => {
 					if (!e.relatedTarget.classList.contains("__cxt-ar-annotation-close__")) {
 						closeButton.style.display ="none";
 						// path.style.cursor = "default";
 						closeButton.style.cursor = "default";
-						path.setAttribute("fill", this.getFinalAnnotationColor(annotationAppearance, false));
+						path.setAttribute("fill", this.getFinalAnnotationColor(annotation, false));
 					}
 				});
 
@@ -140,30 +105,30 @@ class AnnotationRenderer {
 					closeButton.style.display = "none";
 					path.style.cursor = "default";
 					closeButton.style.cursor = "default";
-					path.setAttribute("fill", this.getFinalAnnotationColor(annotationAppearance, false));
+					path.setAttribute("fill", this.getFinalAnnotationColor(annotation, false));
 				});
 
 				el.prepend(bubble);
 			}
 			else if (annotation.type === "highlight") {
 				el.style.backgroundColor = "";
-				el.style.border = `2.5px solid ${this.getFinalAnnotationColor(annotationAppearance, false)}`;
+				el.style.border = `2.5px solid ${this.getFinalAnnotationColor(annotation, false)}`;
 				if (annotation.actionType === "url")
 					el.style.cursor = "pointer";
 			}
 			else if (annotation.style !== "title") {
-				el.style.backgroundColor = this.getFinalAnnotationColor(annotationAppearance);
+				el.style.backgroundColor = this.getFinalAnnotationColor(annotation);
 				el.addEventListener("mouseenter", () => {
-					el.style.backgroundColor = this.getFinalAnnotationColor(annotationAppearance, true);
+					el.style.backgroundColor = this.getFinalAnnotationColor(annotation, true);
 				});
 				el.addEventListener("mouseleave", () => {
-					el.style.backgroundColor = this.getFinalAnnotationColor(annotationAppearance, false);
+					el.style.backgroundColor = this.getFinalAnnotationColor(annotation, false);
 				});
 				if (annotation.actionType === "url")
 					el.style.cursor = "pointer";
 			}
 
-			el.style.color = `#${this.decimalToHex(annotationAppearance.fgColor)}`;
+			el.style.color = `#${this.decimalToHex(annotation.fgColor)}`;
 
 			el.setAttribute("data-ar-type", annotation.type);
 			el.setAttribute("hidden", "");


### PR DESCRIPTION
Currently an `annotationAppearance` in `AnnotationRenderer` is created that adds default styling to annotations. Unfortunately this does not always work as expected, most notably with applying `textSize` to speech bubbles.

This PR moves styling into `AnnotationParser` so that the default styles are applied when an annotation is first created.

Before:
![image](https://user-images.githubusercontent.com/14208607/56167055-beac2380-5f9c-11e9-8d62-d80e8b0ae93a.png)

After:
![image](https://user-images.githubusercontent.com/14208607/56172342-a218e700-5fae-11e9-8aef-2695bfe60655.png)


I'm not sure if this is how you want to handle things. Let me know if there's anything that needs to be fixed.

